### PR TITLE
FEAT: write-behind 기법 예제 코드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,14 +19,16 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
-
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
+	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.118.Final'
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
-	implementation 'io.lettuce.core:lettuce-core'
-
 	implementation 'org.redisson:redisson-spring-boot-starter:3.23.2'
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	implementation 'mysql:mysql-connector-java:8.0.33'
 
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
@@ -34,7 +36,6 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 tasks.named('test') {

--- a/src/main/java/com/redis/archive/RedisArchiveApplication.java
+++ b/src/main/java/com/redis/archive/RedisArchiveApplication.java
@@ -7,6 +7,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class RedisArchiveApplication {
 
 	public static void main(String[] args) {
+
 		SpringApplication.run(RedisArchiveApplication.class, args);
 	}
 

--- a/src/main/java/com/redis/archive/config/RedisConfig.java
+++ b/src/main/java/com/redis/archive/config/RedisConfig.java
@@ -1,0 +1,71 @@
+package com.redis.archive.config;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Value("${spring.data.redis.username}")
+    private String redisUser;
+
+    @Value("${spring.data.redis.password}")
+    private String redisPassword;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(redisHost, redisPort);
+        factory.setPassword(redisPassword);
+        return factory;
+    }
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+
+        String redisUrl = "redis://" +
+                redisHost + ":" + redisPort;
+        config.useSingleServer()
+                .setAddress(redisUrl)
+                .setUsername(redisUser)
+                .setPassword(redisPassword)
+                .setConnectionMinimumIdleSize(2) // 최소 연결 유지
+                .setConnectionPoolSize(10); // 연결 풀 크기 설정
+
+        return Redisson.create(config);
+    }
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule()); // LocalDateTime 지원
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
+        template.setValueSerializer(serializer);
+        template.setHashValueSerializer(serializer);
+
+        return template;
+    }
+}

--- a/src/main/java/com/redis/archive/entity/Test.java
+++ b/src/main/java/com/redis/archive/entity/Test.java
@@ -1,0 +1,25 @@
+package com.redis.archive.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import org.yaml.snakeyaml.events.Event;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+public class Test {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    private String testId;
+    private String name;
+
+    public Test(String testId, Object name){
+        this.testId = testId;
+        this.name = name.toString();
+    }
+}

--- a/src/main/java/com/redis/archive/repository/TestRepository.java
+++ b/src/main/java/com/redis/archive/repository/TestRepository.java
@@ -1,0 +1,9 @@
+package com.redis.archive.repository;
+
+import com.redis.archive.entity.Test;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TestRepository extends JpaRepository<Test, Long> {
+}

--- a/src/main/java/com/redis/archive/util/DummyDataLoader.java
+++ b/src/main/java/com/redis/archive/util/DummyDataLoader.java
@@ -1,0 +1,30 @@
+package com.redis.archive.util;
+
+import com.redis.archive.entity.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DummyDataLoader {
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    private static final String REDIS_KEY_PREFIX = "test2:";
+
+    @Bean
+    public ApplicationRunner loadDummyData() {
+        return args -> {
+            if (Boolean.FALSE.equals(redisTemplate.hasKey(REDIS_KEY_PREFIX + "1"))) {
+                redisTemplate.opsForValue().set(REDIS_KEY_PREFIX + "1", "alice@example.com");
+                redisTemplate.opsForValue().set(REDIS_KEY_PREFIX + "2", "bob@example.com");
+                System.out.println("Redis에 더미 데이터 저장 완료");
+            } else {
+                System.out.println("Redis에 이미 데이터가 존재합니다.");
+            }
+        };
+    }
+}

--- a/src/main/java/com/redis/archive/write/behind/service/WriteBehindService.java
+++ b/src/main/java/com/redis/archive/write/behind/service/WriteBehindService.java
@@ -1,0 +1,71 @@
+package com.redis.archive.write.behind.service;
+
+import com.redis.archive.entity.Test;
+import com.redis.archive.repository.TestRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.actuate.autoconfigure.wavefront.WavefrontProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class WriteBehindService {
+    private final RedisTemplate<String, String> redisTemplate;
+    private final TestRepository testRepository;
+
+    private static final String CACHE_PREFIX = "test2:";
+
+    public void saveTest(String testId, String name){
+        redisTemplate.opsForValue().set(CACHE_PREFIX + testId, name);
+    }
+
+    @Scheduled(fixedRate = 5000)
+    @Transactional
+    public void syncToDB(){
+        Set<String> keys = redisTemplate.keys(CACHE_PREFIX + "*");
+        if (keys != null){
+            for (String key : keys){
+                String testId = key.replace(CACHE_PREFIX, "");
+                String name = redisTemplate.opsForValue().get(key);
+                System.out.println(testId);
+                testRepository.save(new Test(testId, name));
+                redisTemplate.delete(key);
+            }
+        }
+    }
+
+    @Bean
+    @Async
+    public ApplicationRunner runWriteBehind(){
+        return args -> {
+            while(true){
+                int keyCount = 0;
+                ScanOptions options = ScanOptions.scanOptions().match(CACHE_PREFIX + "*").count(100).build();
+                Cursor<byte[]> cursor = redisTemplate.getConnectionFactory().getConnection().scan(options);
+
+                while (cursor.hasNext()) {
+                    keyCount++;
+                    cursor.next();
+                }
+
+                if (keyCount >= 2){
+                    syncToDB();
+                }
+
+                System.out.println("캐시의 크기가 " + keyCount + " 입니다.");
+
+                Thread.sleep(5000);
+            }
+        };
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=redis-archive

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,22 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/redis
+    username: root
+    password: keypass
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+  data:
+    redis:
+      host: redis-18096.c1.us-central1-2.gce.redns.redis-cloud.com  # Redis ?? ?? (???: localhost)
+      port: 18096       # Redis ?? (???: 6379)
+      username: default
+      password: g6PQy8FqLZ683s4GWe19eRQkmKuRjmkk    # Redis? ????? ???? ??? ??
+      timeout: 6000ms
+


### PR DESCRIPTION
`@Component
public class DummyDataLoader {

    @Autowired
    private RedisTemplate<String, String> redisTemplate;

    private static final String REDIS_KEY_PREFIX = "test2:";

    @Bean
    public ApplicationRunner loadDummyData() {
        return args -> {
            if (Boolean.FALSE.equals(redisTemplate.hasKey(REDIS_KEY_PREFIX + "1"))) {
                redisTemplate.opsForValue().set(REDIS_KEY_PREFIX + "1", "alice@example.com");
                redisTemplate.opsForValue().set(REDIS_KEY_PREFIX + "2", "bob@example.com");
                System.out.println("Redis에 더미 데이터 저장 완료");
            } else {
                System.out.println("Redis에 이미 데이터가 존재합니다.");
            }
        };
    }
}`
- 위 코드를 실행해 Redis에 데이터 저장.

`package com.redis.archive.write.behind.service;

import com.redis.archive.entity.Test;
import com.redis.archive.repository.TestRepository;
import lombok.RequiredArgsConstructor;
import org.springframework.boot.ApplicationRunner;
import org.springframework.boot.actuate.autoconfigure.wavefront.WavefrontProperties;
import org.springframework.context.annotation.Bean;
import org.springframework.data.redis.core.Cursor;
import org.springframework.data.redis.core.RedisTemplate;
import org.springframework.data.redis.core.ScanOptions;
import org.springframework.scheduling.annotation.Async;
import org.springframework.scheduling.annotation.Scheduled;
import org.springframework.stereotype.Service;
import org.springframework.transaction.annotation.Transactional;

import java.util.Objects;
import java.util.Set;

@Service
@RequiredArgsConstructor
public class WriteBehindService {
    private final RedisTemplate<String, String> redisTemplate;
    private final TestRepository testRepository;

    private static final String CACHE_PREFIX = "test2:";

    public void saveTest(String testId, String name){
        redisTemplate.opsForValue().set(CACHE_PREFIX + testId, name);
    }

    @Scheduled(fixedRate = 5000)
    @Transactional
    public void syncToDB(){
        Set<String> keys = redisTemplate.keys(CACHE_PREFIX + "*");
        if (keys != null){
            for (String key : keys){
                String testId = key.replace(CACHE_PREFIX, "");
                String name = redisTemplate.opsForValue().get(key);
                System.out.println(testId);
                testRepository.save(new Test(testId, name));
                redisTemplate.delete(key);
            }
        }
    }

    @Bean
    @Async
    public ApplicationRunner runWriteBehind(){
        return args -> {
            while(true){
                int keyCount = 0;
                ScanOptions options = ScanOptions.scanOptions().match(CACHE_PREFIX + "*").count(100).build();
                Cursor<byte[]> cursor = redisTemplate.getConnectionFactory().getConnection().scan(options);

                while (cursor.hasNext()) {
                    keyCount++;
                    cursor.next();
                }

                if (keyCount >= 2){
                    syncToDB();
                }

                System.out.println("캐시의 크기가 " + keyCount + " 입니다.");

                Thread.sleep(5000);
            }
        };
    }
}
`
- Application 실행 시 runWriteBehind는 비동기적으로 실행되어 캐시에 일정 크기만큼의 데이터가 저장되면 DB에 저장.

